### PR TITLE
Add Jest setup and DOM countdown test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Checklist Project
+
+This repo contains a simple HTML checklist.
+
+## Running Tests
+
+1. Ensure Node.js and npm are installed.
+2. Install dependencies (Jest and jsdom):
+   ```sh
+   npm install
+   ```
+3. Run the tests using:
+   ```sh
+   npm test
+   ```
+
+Tests are located under `tests/` and use Jest with a jsdom environment.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "checklist",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/countdown.test.js
+++ b/tests/countdown.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('updateCountdown', () => {
+  test('updates countdown and netdays text', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'Checklist semester 5.html'), 'utf8');
+
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    const { window } = dom;
+
+    const mockNow = new Date('2025-07-12T00:00:00+03:00');
+    const RealDate = window.Date;
+    window.Date = class extends RealDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          return new RealDate(mockNow);
+        }
+        return new RealDate(...args);
+      }
+      static now() {
+        return new RealDate(mockNow).getTime();
+      }
+    };
+
+    window.updateCountdown();
+
+    const countdownText = window.document.getElementById('countdown').textContent;
+    const netdaysText = window.document.getElementById('netdays').textContent;
+
+    expect(countdownText).toContain('🕒 الوقت المتبقي حتى أول امتحان');
+    expect(countdownText).toContain('3 يوم');
+    expect(netdaysText).toBe('📅 أيام المذاكرة المتبقية (صافية): 1 يوم');
+  });
+});


### PR DESCRIPTION
## Summary
- initialize Node project with Jest config
- add a countdown unit test using jsdom
- document test instructions

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f9de2cd08331bd043c4501ee3f2d